### PR TITLE
Add AppleGraphicsDevicePolicy kext patch to help with monitor hotplugging.

### DIFF
--- a/CLOVER/config.plist
+++ b/CLOVER/config.plist
@@ -752,6 +752,24 @@
 				RiV1VHh4eHgA
 				</data>
 			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>Disable board-id check to prevent no signal © lvs1974, Pike R. Alpha, vit9696</string>
+				<key>Disabled</key>
+				<false/>
+				<key>Find</key>
+				<data>
+				ugUAAAA=
+				</data>
+				<key>InfoPlistPatch</key>
+				<false/>
+				<key>Name</key>
+				<string>com.apple.driver.AppleGraphicsDevicePolicy</string>
+				<key>Replace</key>
+				<data>
+				ugAAAAA=
+				</data>
+			</dict>
 		</array>
 	</dict>
 	<key>RtVariables</key>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ This repository contains **my own files** on the installation and configuration 
 
 * Thanks darkhandz for [his High Sierrra guide](https://github.com/darkhandz/XPS15-9550-High-Sierra). Please read darkhandz's guide before you use my files.
 * Use `MacBookPro13,3` SMBIOS, much thanks for @syscl.
-  * Note that you need to modify `AppleGraphicsDevicePolicy.kext` to make external monitors work.
   * The model identifier is also correct now.
   * I hide my serial number as `C02*****GTFN`, you may generate it by your own.
 * `Caps` and `Left-Ctrl` is exchanged in `VoodoooPS2`, you can modify it if you don't like this keyboard layout.
@@ -33,16 +32,8 @@ This repository contains **my own files** on the installation and configuration 
 
 * TB3/type-C port hot-plug maybe work.
     * I find that my TB3-DP adapter can hot-plug and the 4K external monitor works fine. Need more test.
+    * Third-party tests say that DP hot-pluggin is also functioning fine.
     * My Nexus 6P is broken so I can't test.
 * SD card reader (waiting for good news from [this post](http://www.insanelymac.com/forum/topic/321080-sineteks-driver-for-realtek-rtsx-sdhc-card-readers))
 
-## Tips
-
-To make external monitor works (if you use `iMac17,1` SMBIOS), you should do following steps:
-
-1. Open `/System/Library/Extensions/AppleGraphicsControl.kext/Contents/PlugIns/AppleGraphicsDevicePolicy.kext/Contents/Info.plist`.
-2. Find the Borad-ID which used in your config.plist such as "Mac-B809C3757DA9BB8D" or "Mac-65CE76090165799A" or "Mac-DB15BD556843C820".
-3. Replace the attribute `Config2` with `none`
-4. Execute commands `sudo kextcache -system-prelinked-kernel` and `sudo kextcache -system-caches`.
-5. Reboot and everything is done.
 


### PR DESCRIPTION
This patch by PikeAlpha takes care of the need of patching AGDP kext for monitor hotplugging. Also update documentation to remove mention of patching the kext to reduce confusion.